### PR TITLE
fix the public demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Alt-gosling is a library based on [Gosling](https://github.com/gosling-lang/gosl
 There is a large gap in accessibility, specifically for people with blindness and low vision (BLV), on the web. The Web Content Accessibility Guidelines ([WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/)) require text descriptions for images. AltGosling creates text descriptions for genomic visualizations created with Gosling. In this way, interactive visualizations can be deployed on the web and automatically include text descriptions.
 
 ## Demo
-A demo of AltGosling is available [here](https://gosling-lang.github.io/alt-gosling/). 
+A demo of AltGosling is available [here](https://gosling-lang.github.io/altgosling/). 
 
 
 ## Contributing to Alt

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Thomas C. Smits",
   "version": "0.0.0",
   "license": "MIT",
-  "homepage": "https://gosling-lang.github.io/alt-gosling/",
+  "homepage": "https://gosling-lang.github.io/altgosling/",
   "type": "module",
   "scripts": {
     "predeploy": "npm run build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     },
   },
   plugins: [react()],
-  base: '/alt-gosling',
+  base: '/altgosling',
   server: {
     open: 'index.html'
   }


### PR DESCRIPTION
The demo seems unreachable at the moment, and changing the `base` URL in `vite.config.ts` (from `alt-gosling` to `altgosling`) should address this issue.