### PR TITLE
Add simple editor to demo

### DIFF
--- a/demo/DemoFull.tsx
+++ b/demo/DemoFull.tsx
@@ -88,12 +88,11 @@ function Demo() {
                 : null}
                 <Grid item aria-label='altgosling component' xs={12}>
                     { selectedExample === 'editor' ? 
-                        // <AltGoslingComponent spec={editorText} download={true} name={selectedExample} />
                         (editorValid === 'invalid' ? 
                             <Typography variant='body1' color='error'>No Gosling or AltGosling components could be loaded.</Typography>
-                        : <AltGoslingComponent spec={editorText} download={true} name={selectedExample} />
+                        : <AltGoslingComponent spec={editorText} download name={selectedExample} />
                         )
-                    : <AltGoslingComponent spec={examples[selectedExample]} download={true} name={selectedExample} />
+                    : <AltGoslingComponent spec={examples[selectedExample]} download name={selectedExample} />
                     }
                 </Grid>
             </Grid>

--- a/demo/DemoFull.tsx
+++ b/demo/DemoFull.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { validateGoslingSpec } from 'gosling.js';
 import { AltGoslingComponent } from '../src/AltGoslingComponent';
 
 // simple examples
@@ -19,11 +20,7 @@ import { geneAnnotation } from './examples/geneAnnotation';
 import { matrix } from './examples/matrix';
 
 // MUI elements
-import Grid from '@mui/material/Grid';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import Select from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
+import { Grid, FormControl, InputLabel, Select, MenuItem, TextField, Typography } from '@mui/material';
 
 
 function Demo() {
@@ -39,6 +36,8 @@ function Demo() {
                       'Ideogram expression': ideogramWithArea,
                     };
     const [selectedExample, setSelectedExample] = useState<string>(Object.keys(examples)[0]);
+    const [editorText, setEditorText] = useState<string>('');
+    const [editorValid, setEditorValid] = useState<string>('invalid');
 
     const ExampleOptions = () => {
         return (
@@ -52,8 +51,9 @@ function Demo() {
                     onChange={(event) => setSelectedExample(event.target.value)}
                 >
                     {Object.keys(examples).sort().map(e => (
-                        <MenuItem value={e}>{e}</MenuItem>
+                        <MenuItem key={e} value={e}>{e}</MenuItem>
                     ))}
+                    <MenuItem key={"editor"} value="editor">Editor</MenuItem>
                 </Select>
             </FormControl>
         );
@@ -65,8 +65,36 @@ function Demo() {
                 <Grid item aria-label='example checkbox' xs={12}>
                     <ExampleOptions/>
                 </Grid>
+                { selectedExample === 'editor' ?
+                    <Grid item aria-label='editor textfield' xs={12}>
+                        <Typography variant='body1' color={editorValid === 'invalid' ? 'error' : ''}>Gosling spec is {editorValid}</Typography>
+                        <TextField 
+                            id="editor"
+                            multiline 
+                            fullWidth
+                            onChange={(event) => {
+                                setSelectedExample('editor')
+                                const { state, message, details } = validateGoslingSpec(JSON.parse(event.target.value));
+                                if (state !== "success") {
+                                    console.error(message, details);
+                                    setEditorValid('invalid');
+                                } else {
+                                    setEditorValid('valid');
+                                }
+                                setEditorText(JSON.parse(event.target.value))
+                            }}
+                        /> 
+                    </Grid>
+                : null}
                 <Grid item aria-label='altgosling component' xs={12}>
-                    <AltGoslingComponent spec={examples[selectedExample]} download={true} name={selectedExample} />
+                    { selectedExample === 'editor' ? 
+                        // <AltGoslingComponent spec={editorText} download={true} name={selectedExample} />
+                        (editorValid === 'invalid' ? 
+                            <Typography variant='body1' color='error'>No Gosling or AltGosling components could be loaded.</Typography>
+                        : <AltGoslingComponent spec={editorText} download={true} name={selectedExample} />
+                        )
+                    : <AltGoslingComponent spec={examples[selectedExample]} download={true} name={selectedExample} />
+                    }
                 </Grid>
             </Grid>
        </>

--- a/demo/DemoFull.tsx
+++ b/demo/DemoFull.tsx
@@ -73,7 +73,6 @@ function Demo() {
                             multiline 
                             fullWidth
                             onChange={(event) => {
-                                setSelectedExample('editor')
                                 const { state, message, details } = validateGoslingSpec(JSON.parse(event.target.value));
                                 if (state !== "success") {
                                     console.error(message, details);

--- a/src/AltGoslingComponent.tsx
+++ b/src/AltGoslingComponent.tsx
@@ -1,6 +1,6 @@
 
 import { useEffect, useRef, useState } from 'react';
-import { GoslingComponent, type GoslingRef, type GoslingSpec, type HiGlassSpec, type Theme, type TemplateTrackDef } from 'gosling.js';
+import { GoslingComponent, validateGoslingSpec, type GoslingRef, type GoslingSpec, type HiGlassSpec, type Theme, type TemplateTrackDef } from 'gosling.js';
 import type { Datum, AltGoslingSpec, PreviewAlt, DataPanelInformation, AltTrack, AltDataStatistics, AltTrackOverlaidByData, AltTrackOverlaidByMark, AltTrackSingle } from '@altgosling/schema/alt-gosling-schema';
 
 import { getAlt, updateAlt } from './alt-gosling-model';
@@ -47,7 +47,16 @@ export const AltGoslingComponent = (props: AltGoslingCompProps) => {
             throw new Error("The compiled calledback function is used by AltGosling, and cannot be used.");
           } catch (e) {
             console.error(`${(e as Error).name}: ${(e as Error).message}`);
+            return <></>;
           }
+    }
+
+    if (props.spec) {
+        const { state, message, details } = validateGoslingSpec(props.spec);
+        if (state !== "success") {
+            console.error(message, details);
+            return <></>;
+        }
     }
     
     const gosRef = useRef<GoslingRef>(null);
@@ -153,6 +162,11 @@ export const AltGoslingComponent = (props: AltGoslingCompProps) => {
 
     useEffect(() => {
         if (specProcessed) {
+            // Check validity of Gosling spec
+            const { state, message, details } = validateGoslingSpec(props.spec);
+            if (state !== "success") {
+                console.error(message, details);
+            }
             // Get AltGoslingSpec
             const altSpec = getAlt(specProcessed);
             // Set dimensions


### PR DESCRIPTION
Adding a text field to the demo to supply gosling specifications not included in the examples. Input text is validated with `validateGoslingSpec`.