### PR TITLE
feat: bundling and exposing `getAlt` function for the use in nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tmp
 /dist
+/lib
 
 # Dependency directory
 /node_modules

--- a/package.json
+++ b/package.json
@@ -5,12 +5,18 @@
   "license": "MIT",
   "homepage": "https://gosling-lang.github.io/altgosling/",
   "type": "module",
+  "main": "lib/altgosling.js",
+  "module": "lib/altgosling.js",
+  "exports": {
+    ".": "./lib/altgosling.js"
+  },
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
     "dev": "vite",
     "build-only": "vite build",
     "build": "tsc && vite build",
+    "build-lib": "vite build --mode lib",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest"

--- a/src/exported-utils.ts
+++ b/src/exported-utils.ts
@@ -1,0 +1,1 @@
+export { getAlt } from './alt-gosling-model/index.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { AltGoslingComponent } from './AltGoslingComponent.tsx';
+export { getAlt } from './alt-gosling-model/index.ts';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path, { resolve } from 'path'
 
-// https://vitejs.dev/config/
-export default defineConfig({
+const alias = {
+  '@altgosling': path.resolve(__dirname, './src'),
+  '@altgosling/alt-gosling-schema': path.resolve(__dirname, './src/schema/modules/alt-gosling-schema.ts'),
+};
+
+const demo = defineConfig({
   build: {
     rollupOptions: {
       input: {
@@ -11,15 +15,32 @@ export default defineConfig({
       },
     },
   },
-  resolve: {
-    alias: {
-      '@altgosling': path.resolve(__dirname, './src'),
-      '@altgosling/alt-gosling-schema': path.resolve(__dirname, './src/schema/modules/alt-gosling-schema.ts'),
-    },
-  },
+  resolve: { alias },
   plugins: [react()],
   base: '/altgosling',
   server: {
     open: 'index.html'
   }
-})
+});
+
+const lib = defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: 'lib',
+    minify: false,
+    target: 'es2018',
+    sourcemap: true,
+    lib: {
+      entry: {
+        altgosling: path.resolve(__dirname, 'src/index.ts'),
+        utils: path.resolve(__dirname, 'src/utils.ts')
+      },
+      formats: ['es'],
+    },
+  },
+  resolve: { alias },
+
+});
+
+// https://vitejs.dev/config/
+export default ({ mode }) => mode === 'lib' ? lib : demo;


### PR DESCRIPTION
This PR tries to expose utility functions, specifically `getAlt()`. This enables generating alt text in bulk.

I made a separate entry point for utills (i.e., `altgosling/utils`). This enables isolating the React-related code so that `altgosling/utils` can be imported in nodejs (e.g., several variables used in React, such as `window`, are not compatible in nodejs, hence returning errors when importing the entire library (`altgosling`).