### PR TITLE
feat: bundle utils function under a separate entry

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,1 @@
+export { getAlt } from './alt-gosling-model/index.ts';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,8 +33,10 @@ export default defineConfig(({ mode }) => {
   return {
     build: {
       lib: {
-        entry: path.resolve(__dirname, 'src/index.ts'),
-        name: 'altgosling',
+        entry: {
+          altgosling: path.resolve(__dirname, 'src/index.ts'),
+          utils: path.resolve(__dirname, 'src/utils.ts')
+        },
         fileName: (format) => `index.${format}.js`,
       },
       formats: ['es', 'cjs'],


### PR DESCRIPTION
This allows using the `getAlt` function in nodejs:

```ts
import { getAlt } from 'altgosling/utils';
```