### PR TITLE
simplify colors

### DIFF
--- a/demo/DemoFull.tsx
+++ b/demo/DemoFull.tsx
@@ -96,7 +96,7 @@ function Demo() {
                         } else {
                             goslingSpec = examples[selectedExample];
                         }
-                        return <AltGoslingComponent spec={goslingSpec} download name={selectedExample} simplifyColor={true} onAltGoslingSpecUpdate={spec => {
+                        return <AltGoslingComponent spec={goslingSpec} download name={selectedExample} simplifyColorNames={true} onAltGoslingSpecUpdate={spec => {
                             console.log('AltGosling Spec Updated', spec);
                         }} />;
                     })()}

--- a/demo/DemoFull.tsx
+++ b/demo/DemoFull.tsx
@@ -96,7 +96,7 @@ function Demo() {
                         } else {
                             goslingSpec = examples[selectedExample];
                         }
-                        return <AltGoslingComponent spec={goslingSpec} download name={selectedExample} onAltGoslingSpecUpdate={spec => {
+                        return <AltGoslingComponent spec={goslingSpec} download name={selectedExample} simplifyColor={true} onAltGoslingSpecUpdate={spec => {
                             console.log('AltGosling Spec Updated', spec);
                         }} />;
                     })()}

--- a/src/AltGoslingComponent.tsx
+++ b/src/AltGoslingComponent.tsx
@@ -44,7 +44,7 @@ interface AltGoslingCompProps extends GoslingCompProps {
     layoutPanels?: 'vertical' | 'horizontal';
     download?: boolean;
     dataTableRoundValues?: boolean;
-    simplifyColor?: boolean;
+    simplifyColorNames?: boolean;
     onAltGoslingSpecUpdate?: (altSpec: AltGoslingSpec) => void;
 }
 
@@ -176,7 +176,7 @@ export const AltGoslingComponent = (props: AltGoslingCompProps) => {
                 console.error(message, details);
             }
             // Get AltGoslingSpec
-            const altSpec = getAlt(specProcessed, props.simplifyColor);
+            const altSpec = getAlt(specProcessed, props.simplifyColorNames);
             // Set dimensions
             setGoslingDimensions({ width: specProcessed._assignedWidth, height: specProcessed._assignedHeight });
             // Update current alt
@@ -234,7 +234,7 @@ export const AltGoslingComponent = (props: AltGoslingCompProps) => {
         // update altpanel
         const data = rawData;
         if (data) {
-            const updatedAlt = updateAlt(AltPanels.current[selectedAltPanel].data, data.id, data.data, props.theme, props.simplifyColor);
+            const updatedAlt = updateAlt(AltPanels.current[selectedAltPanel].data, data.id, data.data, props.theme, props.simplifyColorNames);
             props.onAltGoslingSpecUpdate?.(updatedAlt);
             updateAltPanelDisplay(updatedAlt);
 

--- a/src/AltGoslingComponent.tsx
+++ b/src/AltGoslingComponent.tsx
@@ -44,6 +44,7 @@ interface AltGoslingCompProps extends GoslingCompProps {
     layoutPanels?: 'vertical' | 'horizontal';
     download?: boolean;
     dataTableRoundValues?: boolean;
+    simplifyColor?: boolean;
     onAltGoslingSpecUpdate?: (altSpec: AltGoslingSpec) => void;
 }
 
@@ -175,7 +176,7 @@ export const AltGoslingComponent = (props: AltGoslingCompProps) => {
                 console.error(message, details);
             }
             // Get AltGoslingSpec
-            const altSpec = getAlt(specProcessed);
+            const altSpec = getAlt(specProcessed, props.simplifyColor);
             // Set dimensions
             setGoslingDimensions({ width: specProcessed._assignedWidth, height: specProcessed._assignedHeight });
             // Update current alt
@@ -233,7 +234,7 @@ export const AltGoslingComponent = (props: AltGoslingCompProps) => {
         // update altpanel
         const data = rawData;
         if (data) {
-            const updatedAlt = updateAlt(AltPanels.current[selectedAltPanel].data, data.id, data.data, props.theme);
+            const updatedAlt = updateAlt(AltPanels.current[selectedAltPanel].data, data.id, data.data, props.theme, props.simplifyColor);
             props.onAltGoslingSpecUpdate?.(updatedAlt);
             updateAltPanelDisplay(updatedAlt);
 

--- a/src/alt-gosling-model/alt-data/alt-from-data.ts
+++ b/src/alt-gosling-model/alt-data/alt-from-data.ts
@@ -96,7 +96,8 @@ export function altUpdateSpecWithData(
     altGoslingSpec: AltGoslingSpec,
     id: string,
     flatTileData: Datum[],
-    theme?: Theme
+    theme?: Theme,
+    simplifyColor?: boolean,
 ): AltGoslingSpec {
 
     const includePosition = altGoslingSpec.tracks.length > 1;
@@ -118,7 +119,7 @@ export function altUpdateSpecWithData(
                 track.data.details.dataStatistics = altDataStatistics;
 
                 // update description
-                addTrackDataDescriptionsTrack(track, theme);
+                addTrackDataDescriptionsTrack(track, theme, simplifyColor);
                 addTrackDescription(track, includePosition);
             }
         }
@@ -136,7 +137,7 @@ export function altUpdateSpecWithData(
                     overlaidDataTrack.data.details.dataStatistics = altDataStatistics;
 
                     // update description
-                    addTrackDataDescriptionsTrack(track, theme);
+                    addTrackDataDescriptionsTrack(track, theme, simplifyColor);
                     addTrackDescription(track, includePosition);
                 }
             }

--- a/src/alt-gosling-model/alt-data/alt-from-data.ts
+++ b/src/alt-gosling-model/alt-data/alt-from-data.ts
@@ -97,7 +97,7 @@ export function altUpdateSpecWithData(
     id: string,
     flatTileData: Datum[],
     theme?: Theme,
-    simplifyColor?: boolean,
+    simplifyColorNames?: boolean,
 ): AltGoslingSpec {
 
     const includePosition = altGoslingSpec.tracks.length > 1;
@@ -119,7 +119,7 @@ export function altUpdateSpecWithData(
                 track.data.details.dataStatistics = altDataStatistics;
 
                 // update description
-                addTrackDataDescriptionsTrack(track, theme, simplifyColor);
+                addTrackDataDescriptionsTrack(track, theme, simplifyColorNames);
                 addTrackDescription(track, includePosition);
             }
         }
@@ -137,7 +137,7 @@ export function altUpdateSpecWithData(
                     overlaidDataTrack.data.details.dataStatistics = altDataStatistics;
 
                     // update description
-                    addTrackDataDescriptionsTrack(track, theme, simplifyColor);
+                    addTrackDataDescriptionsTrack(track, theme, simplifyColorNames);
                     addTrackDescription(track, includePosition);
                 }
             }

--- a/src/alt-gosling-model/alt-text/color.ts
+++ b/src/alt-gosling-model/alt-text/color.ts
@@ -25,24 +25,33 @@ function hexToRgb(hex: string) {
     return rgb;
 }
 
-const colors = {
-    "black": [0, 0, 0],
-    "green": [0, 128, 0],
-    "silver": [192, 192, 192],
-    "lime": [0, 255, 0],
-    "gray": [128, 128, 128],
-    "olive": [128, 128, 0],
-    "white": [255, 255, 255],
-    "yellow": [255, 255, 0],
-    "maroon": [128, 0, 0],
-    "navy": [0, 0, 128],
-    "red": [255, 0, 0],
-    "blue": [0, 0, 255],
-    "purple": [128, 0, 128],
-    "teal": [0, 128, 128],
-    "fuchsia": [255, 0, 255],
-    "aqua": [0, 255, 255]
-};
+const colors = [
+    { name: 'black', hex: '#000000', rgb: [0, 0, 0] },
+    { name: 'dark green', hex: '#008000', rgb: [0, 128, 0] },
+    { name: 'silver', hex: '#C0C0C0', rgb: [192, 192, 192] },
+    { name: 'bright green', hex: '#00FF00', rgb: [0, 255, 0] },
+    { name: 'gray', hex: '#808080', rgb: [128, 128, 128] },
+    { name: 'olive', hex: '#808000', rgb: [128, 128, 0] },
+    { name: 'white', hex: '#FFFFFF', rgb: [255, 255, 255] },
+    { name: 'yellow', hex: '#FFFF00', rgb: [255, 255, 0] },
+    { name: 'maroon', hex: '#800000', rgb: [128, 0, 0] },
+    { name: 'navy', hex: '#000080', rgb: [0, 0, 128] },
+    { name: 'red', hex: '#FF0000', rgb: [255, 0, 0] },
+    { name: 'dark blue', hex: '#0000FF', rgb: [0, 0, 255] },
+    { name: 'purple', hex: '#800080', rgb: [128, 0, 128] },
+    { name: 'teal', hex: '#008080', rgb: [0, 128, 128] },
+    { name: 'pink', hex: '#FF00FF', rgb: [255, 0, 255] },
+    { name: 'light blue', hex: '#00FFFF', rgb: [0, 255, 255] },
+
+    // gosling colors
+    { name: 'orange', hex: '#E79F00', rgb: [231, 159, 0] },
+    { name: 'green', hex: '#029F73', rgb: [2, 159, 115] },
+    { name: 'navy blue', hex: '#0072B2', rgb: [0, 114, 178] },
+    { name: 'pink', hex: '#CB7AA7', rgb: [203, 122, 167] },
+    { name: 'dark orange', hex: '#D45E00', rgb: [212, 94, 0] },
+    { name: 'sky blue', hex: '#57B4E9', rgb: [87, 180, 233] },
+    { name: 'yellow', hex: '#EFE441', rgb: [239, 228, 65] },
+];
 
 
 function colorDistance(c1: number[], c2: number[]) {
@@ -50,17 +59,22 @@ function colorDistance(c1: number[], c2: number[]) {
 }
 
 function findClosestColor(hex: string) {
+    const exactColor = colors.find(color => color.hex.toLowerCase().slice(0) === hex.toLowerCase());
+    if (exactColor) {
+        return exactColor.name;
+    }
+
     const targetRgb = hexToRgb(hex);
     if (!targetRgb) return "unknown color";
 
     let closestColor = "";
     let minDistance = Number.MAX_VALUE;
 
-    for (const [name, rgb] of Object.entries(colors)) {
-        const distance = colorDistance(rgb, targetRgb);
+    for (const color of colors) {
+        const distance = colorDistance(color.rgb, targetRgb);
         if (distance < minDistance) {
             minDistance = distance;
-            closestColor = name;
+            closestColor = color.name;
         }
     }
     return closestColor;

--- a/src/alt-gosling-model/alt-text/color.ts
+++ b/src/alt-gosling-model/alt-text/color.ts
@@ -1,0 +1,69 @@
+import { GetColorName } from 'hex-color-to-color-name';
+
+// Converting colors to names
+
+export function getColorName(color: string, simple?: boolean): string {
+    console.log("color", "simple", color, simple);
+    color = color.replace('#', '');
+    if (simple === undefined || simple === false) {
+        return GetColorName(color).toLowerCase();
+    } else {
+        return findClosestColor(color);
+    }
+}
+
+function hexToRgb(hex: string) {
+    if (hex.length === 3) {
+        hex = hex.split('').map(c => c + c).join('');
+    }
+    if (hex.length !== 6) {
+        throw new Error(`Invalid hex color: ${hex}`);
+    }
+
+    let rgb = [0, 0, 0];
+    rgb = rgb.map((_, i) => parseInt(hex.slice(i * 2, i * 2 + 2), 16));
+    return rgb;
+}
+
+const colors = {
+    "black": [0, 0, 0],
+    "green": [0, 128, 0],
+    "silver": [192, 192, 192],
+    "lime": [0, 255, 0],
+    "gray": [128, 128, 128],
+    "olive": [128, 128, 0],
+    "white": [255, 255, 255],
+    "yellow": [255, 255, 0],
+    "maroon": [128, 0, 0],
+    "navy": [0, 0, 128],
+    "red": [255, 0, 0],
+    "blue": [0, 0, 255],
+    "purple": [128, 0, 128],
+    "teal": [0, 128, 128],
+    "fuchsia": [255, 0, 255],
+    "aqua": [0, 255, 255]
+};
+
+
+function colorDistance(c1: number[], c2: number[]) {
+    return Math.sqrt((c1[0] - c2[0]) ** 2 + (c1[1] - c2[1]) ** 2 + (c1[2] - c2[2]) ** 2);
+}
+
+function findClosestColor(hex: string) {
+    const targetRgb = hexToRgb(hex);
+    if (!targetRgb) return "unknown color";
+
+    let closestColor = "";
+    let minDistance = Number.MAX_VALUE;
+
+    for (const [name, rgb] of Object.entries(colors)) {
+        const distance = colorDistance(rgb, targetRgb);
+        if (distance < minDistance) {
+            minDistance = distance;
+            closestColor = name;
+        }
+    }
+    return closestColor;
+}
+
+

--- a/src/alt-gosling-model/alt-text/color.ts
+++ b/src/alt-gosling-model/alt-text/color.ts
@@ -3,9 +3,8 @@ import { GetColorName } from 'hex-color-to-color-name';
 // Converting colors to names
 
 export function getColorName(color: string, simple?: boolean): string {
-    console.log("color", "simple", color, simple);
     color = color.replace('#', '');
-    if (simple === undefined || simple === false) {
+    if (!simple) {
         return GetColorName(color).toLowerCase();
     } else {
         return findClosestColor(color);
@@ -20,9 +19,8 @@ function hexToRgb(hex: string) {
         throw new Error(`Invalid hex color: ${hex}`);
     }
 
-    let rgb = [0, 0, 0];
-    rgb = rgb.map((_, i) => parseInt(hex.slice(i * 2, i * 2 + 2), 16));
-    return rgb;
+    const rgb = [0, 0, 0];
+    return rgb.map((_, i) => parseInt(hex.slice(i * 2, i * 2 + 2), 16));
 }
 
 const colors = [

--- a/src/alt-gosling-model/alt-text/color.ts
+++ b/src/alt-gosling-model/alt-text/color.ts
@@ -7,7 +7,7 @@ export function getColorName(color: string, simple?: boolean): string {
     if (!simple) {
         return GetColorName(color).toLowerCase();
     } else {
-        return findClosestColor(color);
+        return findClosestColorName(color);
     }
 }
 
@@ -56,7 +56,7 @@ function colorDistance(c1: number[], c2: number[]) {
     return Math.sqrt((c1[0] - c2[0]) ** 2 + (c1[1] - c2[1]) ** 2 + (c1[2] - c2[2]) ** 2);
 }
 
-function findClosestColor(hex: string) {
+function findClosestColorName(hex: string) {
     const exactColor = colors.find(color => color.hex.toLowerCase().slice(0) === hex.toLowerCase());
     if (exactColor) {
         return exactColor.name;

--- a/src/alt-gosling-model/alt-text/index.ts
+++ b/src/alt-gosling-model/alt-text/index.ts
@@ -5,12 +5,12 @@ import { addTrackDataDescriptions } from './text-data';
 import { addGlobalDescription } from './text-global';
 
 
-export function treeText(altGoslingSpec: AltGoslingSpec) {
-    addTreeDescriptions(altGoslingSpec);
+export function treeText(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
+    addTreeDescriptions(altGoslingSpec, simplifyColor);
     addGlobalDescription(altGoslingSpec);
 }
 
-export function dataText(altGoslingSpec: AltGoslingSpec) {
-    addTrackDataDescriptions(altGoslingSpec);
+export function dataText(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
+    addTrackDataDescriptions(altGoslingSpec, undefined, simplifyColor);
     addGlobalDescription(altGoslingSpec);
 }

--- a/src/alt-gosling-model/alt-text/index.ts
+++ b/src/alt-gosling-model/alt-text/index.ts
@@ -5,12 +5,12 @@ import { addTrackDataDescriptions } from './text-data';
 import { addGlobalDescription } from './text-global';
 
 
-export function treeText(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
-    addTreeDescriptions(altGoslingSpec, simplifyColor);
+export function treeText(altGoslingSpec: AltGoslingSpec, simplifyColorNames?: boolean) {
+    addTreeDescriptions(altGoslingSpec, simplifyColorNames);
     addGlobalDescription(altGoslingSpec);
 }
 
-export function dataText(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
-    addTrackDataDescriptions(altGoslingSpec, undefined, simplifyColor);
+export function dataText(altGoslingSpec: AltGoslingSpec, simplifyColorNames?: boolean) {
+    addTrackDataDescriptions(altGoslingSpec, undefined, simplifyColorNames);
     addGlobalDescription(altGoslingSpec);
 }

--- a/src/alt-gosling-model/alt-text/text-data.ts
+++ b/src/alt-gosling-model/alt-text/text-data.ts
@@ -10,10 +10,10 @@ import { getRelativeGenomicPosition } from 'gosling.js/utils';
 import { getThemeColors } from '@altgosling/schema/gosling-theme';
 import { getColorName } from './color';
 
-export function addTrackDataDescriptions(altGoslingSpec: AltGoslingSpec, theme?: Theme, simplifyColor?: boolean) {
+export function addTrackDataDescriptions(altGoslingSpec: AltGoslingSpec, theme?: Theme, simplifyColorNames?: boolean) {
     for (const i in altGoslingSpec.tracks) {
         const track = altGoslingSpec.tracks[i];
-        addTrackDataDescriptionsTrack(track, theme, simplifyColor);
+        addTrackDataDescriptionsTrack(track, theme, simplifyColorNames);
     }
 }
 
@@ -75,19 +75,19 @@ export function getRangeText(p1: number, p2: number, assembly?: Assembly): strin
     return ` The genomic range is shown from chromosome ${p1t[0]} position ${p1t[1]} to chromosome ${p2t[0]} position ${p2t[1]}.`;
 }
 
-export function addTrackDataDescriptionsTrack(track: AltTrack, theme?: Theme, simplifyColor?: boolean) {
+export function addTrackDataDescriptionsTrack(track: AltTrack, theme?: Theme, simplifyColorNames?: boolean) {
     if (track.alttype === 'single' || track.alttype === 'ov-mark') {
-        addTrackDataDescriptionsTrackInd(track, theme, simplifyColor);
+        addTrackDataDescriptionsTrackInd(track, theme, simplifyColorNames);
     }
     if (track.alttype === 'ov-data') {
         for (let i = 0; i < Object.keys(track.tracks).length; i++) {
             const overlaidDataTrack = track.tracks[i];
-            addTrackDataDescriptionsTrackInd(overlaidDataTrack, theme, simplifyColor);
+            addTrackDataDescriptionsTrackInd(overlaidDataTrack, theme, simplifyColorNames);
         }
     }
 }
 
-export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, theme?: Theme, simplifyColor?: boolean) {
+export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, theme?: Theme, simplifyColorNames?: boolean) {
     if (track.data.details.dataStatistics) {
         let desc = '';
         const assembly = track.appearance.details.assembly;
@@ -98,7 +98,7 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
             const genmin = getOnePositionText(track.data.details.dataStatistics?.genomicMin, assembly);
             const genmax = getOnePositionText(track.data.details.dataStatistics?.genomicMax , assembly);
             track.data.details.dataStatistics.genomicDescList = [['Minimum', genmin], ['Maximum', genmax]];
-            linkDataToChannels(track, 'genomic', [['Minimum', `The minimum shown is ${genmin}.`], ['Maximum', `The maximum shown is ${genmax}.`]], undefined, theme, simplifyColor);
+            linkDataToChannels(track, 'genomic', [['Minimum', `The minimum shown is ${genmin}.`], ['Maximum', `The maximum shown is ${genmax}.`]], undefined, theme, simplifyColorNames);
             desc = desc.concat(rangeText);
         }
         if (track.data.details.dataStatistics?.valueMin !== undefined && track.data.details.dataStatistics?.valueMax !== undefined) {
@@ -112,17 +112,17 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
                 const valmaxgen = addMinMaxDescription(track.data.details.dataStatistics?.valueMaxGenomic, 'maximum', assembly);
                 desc = desc.concat(valmaxgen, valmingen);
                 track.data.details.dataStatistics.valueDescList = [['Minimum', `${valmin}. ${valmingen}`], ['Maximum', `${valmax}. ${valmaxgen}`]];
-                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`, `${valmingen}`], ['Maximum', `The maximum value shown is ${valmax}.`, `${valmaxgen}`]], undefined, theme, simplifyColor);
+                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`, `${valmingen}`], ['Maximum', `The maximum value shown is ${valmax}.`, `${valmaxgen}`]], undefined, theme, simplifyColorNames);
             } else {
                 track.data.details.dataStatistics.valueDescList = [['Minimum', `${valmin}`], ['Maximum', `${valmax}`]];
-                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`], ['Maximum', `The maximum value shown is ${valmax}.`]], undefined, theme, simplifyColor);
+                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`], ['Maximum', `The maximum value shown is ${valmax}.`]], undefined, theme, simplifyColorNames);
             }
         }
         // add category data information
         if (track.data.details.dataStatistics?.categories) {
             if (track.data.details.dataStatistics?.categories.length === 1) {
                 desc = desc.concat(` The category shown is called '${track.data.details.dataStatistics?.categories[0]}'.`);
-                linkDataToChannels(track, 'nominal', [['Categories', `There is one category called ${track.data.details.dataStatistics?.categories[0]}`]], undefined, theme, simplifyColor);
+                linkDataToChannels(track, 'nominal', [['Categories', `There is one category called ${track.data.details.dataStatistics?.categories[0]}`]], undefined, theme, simplifyColorNames);
             } else {
                 const linkDataToChannelsList = ['Categories'];
                 // number of categories
@@ -148,7 +148,7 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
                 }
                 // See if genomic positions are the same for the min and max values of each category
 
-                linkDataToChannels(track, 'nominal', [linkDataToChannelsList], track.data.details.dataStatistics?.categories, theme, simplifyColor);
+                linkDataToChannels(track, 'nominal', [linkDataToChannelsList], track.data.details.dataStatistics?.categories, theme, simplifyColorNames);
 
             }
         }
@@ -158,7 +158,7 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
 }
 
 
-function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, typeDescList: string, descList: string[][], categories?: string[], theme?: Theme, simplifyColor?: boolean) {
+function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, typeDescList: string, descList: string[][], categories?: string[], theme?: Theme, simplifyColorNames?: boolean) {
     for (const enc of track.appearance.details.encodingsDescList) {
         if (enc.channelType.includes(typeDescList)) {
             enc.dataDesc = descList;
@@ -194,16 +194,16 @@ function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | Alt
                     case 0: 
                         break;
                     case 1: 
-                        enc.dataDesc[0].push(`The only category (${categories[0]}) is ${getColorName(nominalColors[0], simplifyColor)}.`);
+                        enc.dataDesc[0].push(`The only category (${categories[0]}) is ${getColorName(nominalColors[0], simplifyColorNames)}.`);
                         break;
                     case 2:
-                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColor)} and category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColor)}.`);
+                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColorNames)} and category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColorNames)}.`);
                         break;
                     case 3: 
-                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColor)}, category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColor)} and category ${categories[2]} is ${getColorName(nominalColors[2], simplifyColor)}.`);
+                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColorNames)}, category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColorNames)} and category ${categories[2]} is ${getColorName(nominalColors[2], simplifyColorNames)}.`);
                         break;
                     case 4: 
-                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColor)}, category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColor)}, category ${categories[2]} is ${getColorName(nominalColors[2], simplifyColor)} and category ${categories[3]} is ${getColorName(nominalColors[3], simplifyColor)}.`);
+                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColorNames)}, category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColorNames)}, category ${categories[2]} is ${getColorName(nominalColors[2], simplifyColorNames)} and category ${categories[3]} is ${getColorName(nominalColors[3], simplifyColorNames)}.`);
                         break;
                     default:
                         break;
@@ -218,7 +218,7 @@ function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | Alt
             console.warn("AltGosling was not provided a Gosling Theme, so light theme is assumed.");
         }
         const nominalColors = getThemeColors(theme);
-        const color = getColorName(nominalColors[0], simplifyColor);
+        const color = getColorName(nominalColors[0], simplifyColorNames);
         if (track.appearance.details.mark) {
             track.appearance.details.encodingsDescList.push({channel: 'color', channelType: 'value', desc: `The color of the ${markToText.get(track.appearance.details.mark)} is ${color}.`} as AltEncodingDesc);
         } else {

--- a/src/alt-gosling-model/alt-text/text-data.ts
+++ b/src/alt-gosling-model/alt-text/text-data.ts
@@ -8,13 +8,12 @@ import { arrayToString, markToText, chrNumberOnly, summarizeValueNumber } from '
 import { getRelativeGenomicPosition } from 'gosling.js/utils';
 
 import { getThemeColors } from '@altgosling/schema/gosling-theme';
-import { GetColorName } from 'hex-color-to-color-name';
+import { getColorName } from './color';
 
-
-export function addTrackDataDescriptions(altGoslingSpec: AltGoslingSpec) {
+export function addTrackDataDescriptions(altGoslingSpec: AltGoslingSpec, theme?: Theme, simplifyColor?: boolean) {
     for (const i in altGoslingSpec.tracks) {
         const track = altGoslingSpec.tracks[i];
-        addTrackDataDescriptionsTrack(track);
+        addTrackDataDescriptionsTrack(track, theme, simplifyColor);
     }
 }
 
@@ -76,19 +75,19 @@ export function getRangeText(p1: number, p2: number, assembly?: Assembly): strin
     return ` The genomic range is shown from chromosome ${p1t[0]} position ${p1t[1]} to chromosome ${p2t[0]} position ${p2t[1]}.`;
 }
 
-export function addTrackDataDescriptionsTrack(track: AltTrack, theme?: Theme) {
+export function addTrackDataDescriptionsTrack(track: AltTrack, theme?: Theme, simplifyColor?: boolean) {
     if (track.alttype === 'single' || track.alttype === 'ov-mark') {
-        addTrackDataDescriptionsTrackInd(track, theme);
+        addTrackDataDescriptionsTrackInd(track, theme, simplifyColor);
     }
     if (track.alttype === 'ov-data') {
         for (let i = 0; i < Object.keys(track.tracks).length; i++) {
             const overlaidDataTrack = track.tracks[i];
-            addTrackDataDescriptionsTrackInd(overlaidDataTrack, theme);
+            addTrackDataDescriptionsTrackInd(overlaidDataTrack, theme, simplifyColor);
         }
     }
 }
 
-export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, theme?: Theme) {
+export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, theme?: Theme, simplifyColor?: boolean) {
     if (track.data.details.dataStatistics) {
         let desc = '';
         const assembly = track.appearance.details.assembly;
@@ -99,7 +98,7 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
             const genmin = getOnePositionText(track.data.details.dataStatistics?.genomicMin, assembly);
             const genmax = getOnePositionText(track.data.details.dataStatistics?.genomicMax , assembly);
             track.data.details.dataStatistics.genomicDescList = [['Minimum', genmin], ['Maximum', genmax]];
-            linkDataToChannels(track, 'genomic', [['Minimum', `The minimum shown is ${genmin}.`], ['Maximum', `The maximum shown is ${genmax}.`]]);
+            linkDataToChannels(track, 'genomic', [['Minimum', `The minimum shown is ${genmin}.`], ['Maximum', `The maximum shown is ${genmax}.`]], undefined, theme, simplifyColor);
             desc = desc.concat(rangeText);
         }
         if (track.data.details.dataStatistics?.valueMin !== undefined && track.data.details.dataStatistics?.valueMax !== undefined) {
@@ -113,17 +112,17 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
                 const valmaxgen = addMinMaxDescription(track.data.details.dataStatistics?.valueMaxGenomic, 'maximum', assembly);
                 desc = desc.concat(valmaxgen, valmingen);
                 track.data.details.dataStatistics.valueDescList = [['Minimum', `${valmin}. ${valmingen}`], ['Maximum', `${valmax}. ${valmaxgen}`]];
-                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`, `${valmingen}`], ['Maximum', `The maximum value shown is ${valmax}.`, `${valmaxgen}`]]);
+                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`, `${valmingen}`], ['Maximum', `The maximum value shown is ${valmax}.`, `${valmaxgen}`]], undefined, theme, simplifyColor);
             } else {
                 track.data.details.dataStatistics.valueDescList = [['Minimum', `${valmin}`], ['Maximum', `${valmax}`]];
-                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`], ['Maximum', `The maximum value shown is ${valmax}.`]]);
+                linkDataToChannels(track, 'quantitative', [['Minimum', `The minimum value shown is ${valmin}.`], ['Maximum', `The maximum value shown is ${valmax}.`]], undefined, theme, simplifyColor);
             }
         }
         // add category data information
         if (track.data.details.dataStatistics?.categories) {
             if (track.data.details.dataStatistics?.categories.length === 1) {
                 desc = desc.concat(` The category shown is called '${track.data.details.dataStatistics?.categories[0]}'.`);
-                linkDataToChannels(track, 'nominal', [['Categories', `There is one category called ${track.data.details.dataStatistics?.categories[0]}`]]);
+                linkDataToChannels(track, 'nominal', [['Categories', `There is one category called ${track.data.details.dataStatistics?.categories[0]}`]], undefined, theme, simplifyColor);
             } else {
                 const linkDataToChannelsList = ['Categories'];
                 // number of categories
@@ -139,7 +138,6 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
 
                 // which category has the highest expression peak
                 if (track.data.details.dataStatistics?.highestCategory) {
-                    // console.log('highest cat', track.data.details.dataStatistics?.highestCategory)
                     if (track.data.details.dataStatistics?.highestCategory.length === 1) {
                         desc = desc.concat(` The highest value is observed in category ${track.data.details.dataStatistics?.highestCategory[0]}.`);
                         linkDataToChannelsList.push(`The highest value is observed in category ${track.data.details.dataStatistics?.highestCategory[0]}.`);
@@ -150,7 +148,7 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
                 }
                 // See if genomic positions are the same for the min and max values of each category
 
-                linkDataToChannels(track, 'nominal', [linkDataToChannelsList], track.data.details.dataStatistics?.categories, theme);
+                linkDataToChannels(track, 'nominal', [linkDataToChannelsList], track.data.details.dataStatistics?.categories, theme, simplifyColor);
 
             }
         }
@@ -160,7 +158,7 @@ export function addTrackDataDescriptionsTrackInd(track: AltTrackSingle | AltTrac
 }
 
 
-function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, typeDescList: string, descList: string[][], categories?: string[], theme?: Theme) {
+function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, typeDescList: string, descList: string[][], categories?: string[], theme?: Theme, simplifyColor?: boolean) {
     for (const enc of track.appearance.details.encodingsDescList) {
         if (enc.channelType.includes(typeDescList)) {
             enc.dataDesc = descList;
@@ -196,16 +194,16 @@ function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | Alt
                     case 0: 
                         break;
                     case 1: 
-                        enc.dataDesc[0].push(`The only category (${categories[0]}) is ${GetColorName(nominalColors[0])}.`);
+                        enc.dataDesc[0].push(`The only category (${categories[0]}) is ${getColorName(nominalColors[0], simplifyColor)}.`);
                         break;
                     case 2:
-                        enc.dataDesc[0].push(`Category ${categories[0]} is ${GetColorName(nominalColors[0]).toLowerCase()} and category ${categories[1]} is ${GetColorName(nominalColors[1]).toLowerCase()}.`);
+                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColor)} and category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColor)}.`);
                         break;
                     case 3: 
-                        enc.dataDesc[0].push(`Category ${categories[0]} is ${GetColorName(nominalColors[0]).toLowerCase()}, category ${categories[1]} is ${GetColorName(nominalColors[1]).toLowerCase()} and category ${categories[2]} is ${GetColorName(nominalColors[2]).toLowerCase()}.`);
+                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColor)}, category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColor)} and category ${categories[2]} is ${getColorName(nominalColors[2], simplifyColor)}.`);
                         break;
                     case 4: 
-                        enc.dataDesc[0].push(`Category ${categories[0]} is ${GetColorName(nominalColors[0]).toLowerCase()}, category ${categories[1]} is ${GetColorName(nominalColors[1]).toLowerCase()}, category ${categories[2]} is ${GetColorName(nominalColors[2]).toLowerCase()} and category ${categories[3]} is ${GetColorName(nominalColors[3]).toLowerCase()}.`);
+                        enc.dataDesc[0].push(`Category ${categories[0]} is ${getColorName(nominalColors[0], simplifyColor)}, category ${categories[1]} is ${getColorName(nominalColors[1], simplifyColor)}, category ${categories[2]} is ${getColorName(nominalColors[2], simplifyColor)} and category ${categories[3]} is ${getColorName(nominalColors[3], simplifyColor)}.`);
                         break;
                     default:
                         break;
@@ -220,7 +218,7 @@ function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | Alt
             console.warn("AltGosling was not provided a Gosling Theme, so light theme is assumed.");
         }
         const nominalColors = getThemeColors(theme);
-        const color = GetColorName(nominalColors[0]).toLowerCase();
+        const color = getColorName(nominalColors[0], simplifyColor);
         if (track.appearance.details.mark) {
             track.appearance.details.encodingsDescList.push({channel: 'color', channelType: 'value', desc: `The color of the ${markToText.get(track.appearance.details.mark)} is ${color}.`} as AltEncodingDesc);
         } else {

--- a/src/alt-gosling-model/alt-text/text-tree.ts
+++ b/src/alt-gosling-model/alt-text/text-tree.ts
@@ -3,9 +3,9 @@ import { arrayToString, markToText, channelToText, capDesc } from '../util';
 
 import { getColorName } from './color';
 
-export function addTreeDescriptions(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
+export function addTreeDescriptions(altGoslingSpec: AltGoslingSpec, simplifyColorNames?: boolean) {
     addTrackPositionDescriptions(altGoslingSpec);
-    addTrackAppearanceDescriptions(altGoslingSpec, simplifyColor);
+    addTrackAppearanceDescriptions(altGoslingSpec, simplifyColorNames);
 }
 
 function addTrackPositionDescriptions(altGoslingSpec: AltGoslingSpec) {
@@ -183,7 +183,7 @@ function addTrackPositionDescriptionsMulti(altGoslingSpec: AltGoslingSpec) {
 
 
 
-function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
+function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplifyColorNames?: boolean) {
     for (const i in altGoslingSpec.tracks) {
         const track = altGoslingSpec.tracks[i];
 
@@ -196,7 +196,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplify
                 desc = desc.concat(` Chart is titled '${track.title}'.`);
             }
     
-            const encodingDescriptions = addEncodingDescriptions(track, simplifyColor);
+            const encodingDescriptions = addEncodingDescriptions(track, simplifyColorNames);
 
             desc = desc.concat(` ${encodingDescriptions.desc}`);
 
@@ -220,7 +220,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplify
                 desc = desc.concat(` Chart is titled '${track.title}'.`);
             }
 
-            const encodingDescriptions = addEncodingDescriptions(track, simplifyColor);
+            const encodingDescriptions = addEncodingDescriptions(track, simplifyColorNames);
 
             desc = desc.concat(' ' + encodingDescriptions.desc);
 
@@ -241,7 +241,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplify
                 let descTrack = '';
                 descTrack = descTrack.concat(`${capDesc(overlaidDataTrack.charttype)}.`);
 
-                const encodingDescriptions = addEncodingDescriptions(overlaidDataTrack, simplifyColor);
+                const encodingDescriptions = addEncodingDescriptions(overlaidDataTrack, simplifyColorNames);
 
                 descTrack = descTrack.concat(' ' + encodingDescriptions.desc);
             
@@ -252,7 +252,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplify
     }
 }
 
-function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, simplifyColor?: boolean) {
+function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, simplifyColorNames?: boolean) {
     let mark;
     let marks;
     let markText;
@@ -260,7 +260,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
     if (track.alttype === 'single' || (track.alttype === 'ov-mark' && track.appearance.details.mark) || track.alttype === 'ov-data-ind') {
         mark = track.appearance.details.mark as string;
         markText = markToText.get(mark) as string;
-        const {descGenomic, descQuantitative, descNominal, descValue, descList} = addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColor);
+        const {descGenomic, descQuantitative, descNominal, descValue, descList} = addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColorNames);
         const desc = [descGenomic, descQuantitative, descNominal, descValue].join(' ');
         return {desc: desc, descList: descList};
     } else {
@@ -268,12 +268,12 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
         const descriptionsList = [];
 
         markText = arrayToString(marks.filter(m => m !== undefined).map(m => markToText.get(m)).filter(m => m !== undefined));
-        descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColor));
+        descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColorNames));
 
         for (let i = 0; i < marks.length; i++) {
             if (marks[i]) {
                 markText = markToText.get(marks[i]) as string;
-                descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodingsByTrack[i], simplifyColor));
+                descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodingsByTrack[i], simplifyColorNames));
             }
         }
         
@@ -302,7 +302,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
     }
 }
 
-function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSeparated, simplifyColor?: boolean) {
+function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSeparated, simplifyColorNames?: boolean) {
     let descGenomic = '';
     let descQuantitative = '';
     let descNominal = '';
@@ -507,7 +507,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
             // if the color is denoted as a hex code, get the name of the color value
             if (typeof e.details.value === 'string') {
                 if (e.details.value[0] === '#') {
-                    e.details.value = getColorName(e.details.value, simplifyColor);
+                    e.details.value = getColorName(e.details.value, simplifyColorNames);
                 }
             }
             descValue = descValue.concat(`The color of the ${markText} is ${e.details.value}.`);

--- a/src/alt-gosling-model/alt-text/text-tree.ts
+++ b/src/alt-gosling-model/alt-text/text-tree.ts
@@ -1,11 +1,11 @@
 import type { AltEncodingDesc, AltEncodingSeparated, AltGoslingSpec, AltTrackOverlaidByDataInd, AltTrackOverlaidByMark, AltTrackSingle } from '@altgosling/schema/alt-gosling-schema';
 import { arrayToString, markToText, channelToText, capDesc } from '../util';
 
-import { GetColorName } from 'hex-color-to-color-name';
+import { getColorName } from './color';
 
-export function addTreeDescriptions(altGoslingSpec: AltGoslingSpec) {
+export function addTreeDescriptions(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
     addTrackPositionDescriptions(altGoslingSpec);
-    addTrackAppearanceDescriptions(altGoslingSpec);
+    addTrackAppearanceDescriptions(altGoslingSpec, simplifyColor);
 }
 
 function addTrackPositionDescriptions(altGoslingSpec: AltGoslingSpec) {
@@ -183,7 +183,7 @@ function addTrackPositionDescriptionsMulti(altGoslingSpec: AltGoslingSpec) {
 
 
 
-function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec) {
+function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec, simplifyColor?: boolean) {
     for (const i in altGoslingSpec.tracks) {
         const track = altGoslingSpec.tracks[i];
 
@@ -196,7 +196,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec) {
                 desc = desc.concat(` Chart is titled '${track.title}'.`);
             }
     
-            const encodingDescriptions = addEncodingDescriptions(track);
+            const encodingDescriptions = addEncodingDescriptions(track, simplifyColor);
 
             desc = desc.concat(` ${encodingDescriptions.desc}`);
 
@@ -220,7 +220,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec) {
                 desc = desc.concat(` Chart is titled '${track.title}'.`);
             }
 
-            const encodingDescriptions = addEncodingDescriptions(track);
+            const encodingDescriptions = addEncodingDescriptions(track, simplifyColor);
 
             desc = desc.concat(' ' + encodingDescriptions.desc);
 
@@ -241,7 +241,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec) {
                 let descTrack = '';
                 descTrack = descTrack.concat(`${capDesc(overlaidDataTrack.charttype)}.`);
 
-                const encodingDescriptions = addEncodingDescriptions(overlaidDataTrack);
+                const encodingDescriptions = addEncodingDescriptions(overlaidDataTrack, simplifyColor);
 
                 descTrack = descTrack.concat(' ' + encodingDescriptions.desc);
             
@@ -252,7 +252,7 @@ function addTrackAppearanceDescriptions(altGoslingSpec: AltGoslingSpec) {
     }
 }
 
-function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd) {
+function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, simplifyColor?: boolean) {
     let mark;
     let marks;
     let markText;
@@ -260,7 +260,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
     if (track.alttype === 'single' || (track.alttype === 'ov-mark' && track.appearance.details.mark) || track.alttype === 'ov-data-ind') {
         mark = track.appearance.details.mark as string;
         markText = markToText.get(mark) as string;
-        const {descGenomic, descQuantitative, descNominal, descValue, descList} = addEncodingDescriptionsAll(markText, track.appearance.details.encodings);
+        const {descGenomic, descQuantitative, descNominal, descValue, descList} = addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColor);
         const desc = [descGenomic, descQuantitative, descNominal, descValue].join(' ');
         return {desc: desc, descList: descList};
     } else {
@@ -268,12 +268,12 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
         const descriptionsList = [];
 
         markText = arrayToString(marks.filter(m => m !== undefined).map(m => markToText.get(m)).filter(m => m !== undefined));
-        descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodings));
+        descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColor));
 
         for (let i = 0; i < marks.length; i++) {
             if (marks[i]) {
                 markText = markToText.get(marks[i]) as string;
-                descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodingsByTrack[i]));
+                descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodingsByTrack[i], simplifyColor));
             }
         }
         
@@ -302,7 +302,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
     }
 }
 
-function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSeparated) {
+function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSeparated, simplifyColor?: boolean) {
     let descGenomic = '';
     let descQuantitative = '';
     let descNominal = '';
@@ -507,7 +507,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
             // if the color is denoted as a hex code, get the name of the color value
             if (typeof e.details.value === 'string') {
                 if (e.details.value[0] === '#') {
-                    e.details.value = GetColorName(e.details.value.slice(0)).toLowerCase();
+                    e.details.value = getColorName(e.details.value, simplifyColor);
                 }
             }
             descValue = descValue.concat(`The color of the ${markText} is ${e.details.value}.`);
@@ -652,7 +652,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
 //             // if the color is denoted as a hex code, get the name of the color value
 //             if (typeof e.details.value === 'string') {
 //                 if (e.details.value[0] === '#') {
-//                     e.details.value = GetColorName(e.details.value.slice(0)).toLowerCase();
+//                     e.details.value = getColorName(e.details.value.slice(0)).toLowerCase();
 //                 }
 //             }
 //             descValue = descValue.concat('The color of the ' + markToText.get(mark) + ' is ' + e.details.value + '.');

--- a/src/alt-gosling-model/index.ts
+++ b/src/alt-gosling-model/index.ts
@@ -9,13 +9,14 @@ import type { Theme } from 'gosling.js';
 // this function is only called once every time a spec is compiled
 export function getAlt(
     specProcessed: GoslingSpec,
+    simplifyColor?: boolean,
 ): AltGoslingSpec {
     // get altSpec
     const altSpec = getAltSpec(specProcessed) as AltGoslingSpec;
 
     // add descriptions
-    treeText(altSpec);
-    dataText(altSpec);
+    treeText(altSpec, simplifyColor);
+    dataText(altSpec, simplifyColor);
 
     return altSpec;
 }
@@ -25,7 +26,8 @@ export function updateAlt(
     altGoslingSpec: AltGoslingSpec,
     id: string,
     flatTileData: Datum[],
-    theme?: Theme
+    theme?: Theme,
+    simplifyColor?: boolean,
 ): AltGoslingSpec {
-    return altUpdateSpecWithData(altGoslingSpec, id, flatTileData, theme);
+    return altUpdateSpecWithData(altGoslingSpec, id, flatTileData, theme, simplifyColor);
 }

--- a/src/alt-gosling-model/index.ts
+++ b/src/alt-gosling-model/index.ts
@@ -9,14 +9,14 @@ import type { Theme } from 'gosling.js';
 // this function is only called once every time a spec is compiled
 export function getAlt(
     specProcessed: GoslingSpec,
-    simplifyColor?: boolean,
+    simplifyColorNames?: boolean,
 ): AltGoslingSpec {
     // get altSpec
     const altSpec = getAltSpec(specProcessed) as AltGoslingSpec;
 
     // add descriptions
-    treeText(altSpec, simplifyColor);
-    dataText(altSpec, simplifyColor);
+    treeText(altSpec, simplifyColorNames);
+    dataText(altSpec, simplifyColorNames);
 
     return altSpec;
 }
@@ -27,7 +27,7 @@ export function updateAlt(
     id: string,
     flatTileData: Datum[],
     theme?: Theme,
-    simplifyColor?: boolean,
+    simplifyColorNames?: boolean,
 ): AltGoslingSpec {
-    return altUpdateSpecWithData(altGoslingSpec, id, flatTileData, theme, simplifyColor);
+    return altUpdateSpecWithData(altGoslingSpec, id, flatTileData, theme, simplifyColorNames);
 }


### PR DESCRIPTION
this PR adds a prop `simplifyColor`. When set to `true`, it will take an approximate color name (from a default list, calculated in RBG space) rather than the most exact with the `hex-color-to-color-name` package