### PR TITLE
ci: add a github workflow for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - uses: pnpm/action-setup@v2
+      - run: pnpm install
+      - run: pnpm build-lib
+      - run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,15 @@ yarn pack
 You can then add this .tgz file with pnpm, or refer to it as follows:
 `"gosling.js": "file:<relative path to file>"`
 
+## Releasing a new version
+
+GitHub Action handles bumping the version of AltGosling. The following commands will automatically increase the version number and release the new version in the NPM server.
+
+```sh
+pnpm version --patch # or --minor or --major
+git push origin master --tags
+```
+
 ## Structure
 
 This project consists of three components


### PR DESCRIPTION
This will make the release process easier. Whenever we want to publish a new version, we can run the following:

```sh
pnpm version --patch # or --minor or --major
git push origin master --tags
```

- [ ] `NPM_TOKEN` needs to be added ([how to create this token](https://docs.npmjs.com/creating-and-viewing-access-tokens), [where to put this in the repo](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions))