### PR TITLE
fix incorrect color names

### DIFF
--- a/src/alt-gosling-model/index.ts
+++ b/src/alt-gosling-model/index.ts
@@ -1,5 +1,5 @@
 import type { GoslingSpec, Datum } from '@altgosling/schema/gosling.schema';
-import type {  AltGoslingSpec } from '@altgosling/schema/alt-gosling-schema';
+import type { AltGoslingSpec } from '@altgosling/schema/alt-gosling-schema';
 
 import { getAltSpec } from './alt-structure/alt-from-spec';
 import { treeText, dataText } from './alt-text';
@@ -11,8 +11,10 @@ export function getAlt(
     specProcessed: GoslingSpec,
     simplifyColorNames?: boolean,
 ): AltGoslingSpec {
+    const specProcessedCopy = JSON.parse(JSON.stringify(specProcessed));
+
     // get altSpec
-    const altSpec = getAltSpec(specProcessed) as AltGoslingSpec;
+    const altSpec = getAltSpec(specProcessedCopy) as AltGoslingSpec;
 
     // add descriptions
     treeText(altSpec, simplifyColorNames);


### PR DESCRIPTION
This PR creates the copy of the `specProcessed` and passes that over to `getAltSpec`. If `specProcessed` shouldn't be edited at all, I think this will fix the issue with incorrect color names.

![Screenshot 2025-03-13 at 4 53 43 PM](https://github.com/user-attachments/assets/ef205b10-cc26-4e55-9d5f-390504c45385)
