### PR TITLE
Fix unknown errors

### DIFF
--- a/src/alt-gosling-model/alt-structure/alt-from-spec.ts
+++ b/src/alt-gosling-model/alt-structure/alt-from-spec.ts
@@ -90,8 +90,13 @@ function determineStructure(
             } else {
                 // otherwise treat every track as a single track
                 for (let i = 0; i < specPart.tracks.length; i++) {
-                    const track =  specPart.tracks[i] as SingleTrack;
-                    altSpec.tracks[counter.nTracks] = altSingleTrack(track, altParentValuesCopy, counter);
+                    const track =  specPart.tracks[i];
+
+                    if (IsOverlaidTrack(track)) {
+                        altSpec.tracks[counter.nTracks] = altOverlaidTrack(track as OverlaidTrack, altParentValuesCopy, counter);
+                    } else {
+                        altSpec.tracks[counter.nTracks] = altSingleTrack(track as SingleTrack, altParentValuesCopy, counter);
+                    }
                     if (counter.nTracks > 0) {
                         counter.allPositions = [...counter.allPositions, [counter.rowViews, counter.colViews]];
                     }

--- a/src/alt-gosling-model/alt-structure/chart-types.ts
+++ b/src/alt-gosling-model/alt-structure/chart-types.ts
@@ -1,5 +1,5 @@
 import type { AltTrackSingle, AltTrackOverlaidByMark, AltTrackOverlaidByData, AltTrackOverlaidByDataInd } from '@altgosling/schema/alt-gosling-schema';
-import { arrayToString, markToText } from './../util';
+import { arrayToString, callMarkToText } from './../util';
 
 export function determineSpecialCases(altTrack: AltTrackSingle | AltTrackOverlaidByMark | AltTrackOverlaidByDataInd, markIndex?: number): string {
     let _mark;
@@ -56,8 +56,8 @@ export function determineSpecialCases(altTrack: AltTrackSingle | AltTrackOverlai
     if (_mark === 'rule' && _allEncodings.includes('y')) {
         return `${layoutDesc}chart with horizontal lines`;
     }
-    if (markToText.get(_mark)) {
-        return `${layoutDesc}chart with ${markToText.get(_mark)}`;
+    if (callMarkToText(_mark)) {
+        return `${layoutDesc}chart with ${callMarkToText(_mark)}`;
     }
     
     return `unknown chart`;

--- a/src/alt-gosling-model/alt-text/text-data.ts
+++ b/src/alt-gosling-model/alt-text/text-data.ts
@@ -2,7 +2,7 @@ import type { Assembly, GenomicPosition } from '@altgosling/schema/gosling.schem
 import type { Theme } from 'gosling.js';
 import type { AltEncodingDesc, AltGoslingSpec, AltTrack, AltTrackOverlaidByDataInd, AltTrackOverlaidByMark, AltTrackSingle } from '@altgosling/schema/alt-gosling-schema';
 
-import { arrayToString, markToText, chrNumberOnly, summarizeValueNumber } from '../util';
+import { arrayToString, callMarkToText, chrNumberOnly, summarizeValueNumber } from '../util';
 
 // @ts-expect-error no type definition
 import { getRelativeGenomicPosition } from 'gosling.js/utils';
@@ -220,7 +220,7 @@ function linkDataToChannels(track: AltTrackSingle | AltTrackOverlaidByMark | Alt
         const nominalColors = getThemeColors(theme);
         const color = getColorName(nominalColors[0], simplifyColorNames);
         if (track.appearance.details.mark) {
-            track.appearance.details.encodingsDescList.push({channel: 'color', channelType: 'value', desc: `The color of the ${markToText.get(track.appearance.details.mark)} is ${color}.`} as AltEncodingDesc);
+            track.appearance.details.encodingsDescList.push({channel: 'color', channelType: 'value', desc: `The color of the ${callMarkToText(track.appearance.details.mark)} is ${color}.`} as AltEncodingDesc);
         } else {
             track.appearance.details.encodingsDescList.push({channel: 'color', channelType: 'value', desc: `The color is ${color}.`} as AltEncodingDesc);
         }  

--- a/src/alt-gosling-model/alt-text/text-tree.ts
+++ b/src/alt-gosling-model/alt-text/text-tree.ts
@@ -259,7 +259,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
     
     if (track.alttype === 'single' || (track.alttype === 'ov-mark' && track.appearance.details.mark) || track.alttype === 'ov-data-ind') {
         mark = track.appearance.details.mark as string;
-        markText = callMarkToText(mark) as string;
+        markText = callMarkToText(mark);
         const {descGenomic, descQuantitative, descNominal, descValue, descList} = addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColorNames);
         const desc = [descGenomic, descQuantitative, descNominal, descValue].join(' ');
         return {desc: desc, descList: descList};
@@ -272,7 +272,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
 
         for (let i = 0; i < marks.length; i++) {
             if (marks[i]) {
-                markText = callMarkToText(marks[i]) as string;
+                markText = callMarkToText(marks[i]);
                 descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodingsByTrack[i], simplifyColorNames));
             }
         }
@@ -463,7 +463,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
             } as AltEncodingDesc);
             for (const q of nominalEncodingsINames) {
                 descList.push({
-                    channel: callChannelToText(q) as string,
+                    channel: callChannelToText(q),
                     desc: `The ${callChannelToText(q)} of the ${markText} show the different categories.`,
                     channelType: 'nominal'
                 } as AltEncodingDesc);
@@ -475,7 +475,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
             descNominal = descNominal.concat(`The categories are shown with the ${arrayToString(nominalEncodingsINames)} of the ${markText}.`);
             for (const q of nominalEncodingsI) {
                 descList.push({
-                    channel: callChannelToText(q) as string,
+                    channel: callChannelToText(q),
                     desc: `The ${callChannelToText(q)} of the ${markText} show the different categories.`,
                     channelType: 'nominal'
                 } as AltEncodingDesc);
@@ -494,7 +494,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
         else {
             descNominal = descNominal.concat(`The ${callChannelToText(nominalEncodingsI[0])} of the ${markText} indicates the different categories.`);
             descList.push({
-                channel: callChannelToText(nominalEncodingsI[0]) as string,
+                channel: callChannelToText(nominalEncodingsI[0]),
                 desc: `The ${callChannelToText(nominalEncodingsI[0])} of the ${markText} show the different categories.`,
                 channelType: 'nominal'
             } as AltEncodingDesc);

--- a/src/alt-gosling-model/alt-text/text-tree.ts
+++ b/src/alt-gosling-model/alt-text/text-tree.ts
@@ -1,5 +1,5 @@
 import type { AltEncodingDesc, AltEncodingSeparated, AltGoslingSpec, AltTrackOverlaidByDataInd, AltTrackOverlaidByMark, AltTrackSingle } from '@altgosling/schema/alt-gosling-schema';
-import { arrayToString, markToText, channelToText, capDesc } from '../util';
+import { arrayToString, callMarkToText, callChannelToText, capDesc } from '../util';
 
 import { getColorName } from './color';
 
@@ -259,7 +259,7 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
     
     if (track.alttype === 'single' || (track.alttype === 'ov-mark' && track.appearance.details.mark) || track.alttype === 'ov-data-ind') {
         mark = track.appearance.details.mark as string;
-        markText = markToText.get(mark) as string;
+        markText = callMarkToText(mark) as string;
         const {descGenomic, descQuantitative, descNominal, descValue, descList} = addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColorNames);
         const desc = [descGenomic, descQuantitative, descNominal, descValue].join(' ');
         return {desc: desc, descList: descList};
@@ -267,12 +267,12 @@ function addEncodingDescriptions(track: AltTrackSingle | AltTrackOverlaidByMark 
         marks = track.appearance.details.markByTrack as string[];
         const descriptionsList = [];
 
-        markText = arrayToString(marks.filter(m => m !== undefined).map(m => markToText.get(m)).filter(m => m !== undefined));
+        markText = arrayToString(marks.filter(m => m !== undefined).map(m => callMarkToText(m)).filter(m => m !== undefined));
         descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodings, simplifyColorNames));
 
         for (let i = 0; i < marks.length; i++) {
             if (marks[i]) {
-                markText = markToText.get(marks[i]) as string;
+                markText = callMarkToText(marks[i]) as string;
                 descriptionsList.push(addEncodingDescriptionsAll(markText, track.appearance.details.encodingsByTrack[i], simplifyColorNames));
             }
         }
@@ -416,7 +416,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
         for (const q of quantitativeEncodingsI) {
             descList.push({
                 channel: q,
-                desc: `The ${channelToText.get(q)} of the ${markText} shows the expression values.`,
+                desc: `The ${callChannelToText(q)} of the ${markText} shows the expression values.`,
                 channelType: 'quantitative'
             } as AltEncodingDesc);
         }
@@ -440,8 +440,8 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
         else {
             descQuantitative = descQuantitative.concat(`The height of the expression values is shown with the ${quantitativeEncodingsI[0]}-axis.`);
             descList.push({
-                channel: channelToText.get(quantitativeEncodingsI[0]) as string,
-                desc: `The ${channelToText.get(quantitativeEncodingsI[0])} of the ${markText} shows the expression values.`,
+                channel: callChannelToText(quantitativeEncodingsI[0]),
+                desc: `The ${callChannelToText(quantitativeEncodingsI[0])} of the ${markText} shows the expression values.`,
                 channelType: 'quantitative'
             } as AltEncodingDesc);
         }
@@ -454,7 +454,7 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
     if (nominalEncodingsI.length > 1) {
         if (nominalEncodingsI.includes('row')) {
             descNominal = descNominal.concat(`The chart is stratified by rows for the categories.`);
-            const nominalEncodingsINames = nominalEncodingsI.filter(e => e !== 'row').map(e => channelToText.get(e)) as string[];
+            const nominalEncodingsINames = nominalEncodingsI.filter(e => e !== 'row').map(e => callChannelToText(e)) as string[];
             descNominal = descNominal.concat(` The categories are also shown with the ${arrayToString(nominalEncodingsINames)} of the ${markText}.`);
             descList.push({
                 channel: 'row',
@@ -463,19 +463,20 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
             } as AltEncodingDesc);
             for (const q of nominalEncodingsINames) {
                 descList.push({
-                    channel: channelToText.get(q) as string,
-                    desc: `The ${channelToText.get(q)} of the ${markText} show the different categories.`,
+                    channel: callChannelToText(q) as string,
+                    desc: `The ${callChannelToText(q)} of the ${markText} show the different categories.`,
                     channelType: 'nominal'
                 } as AltEncodingDesc);
             }
         }
         else {
-            const nominalEncodingsINames = nominalEncodingsI.map(e => channelToText.get(e)) as string[];
+            const nominalEncodingsINames = nominalEncodingsI.map(e => callChannelToText(e)) as string[];
+            console.log("nominalEncodingsINames", nominalEncodingsI, nominalEncodingsINames);
             descNominal = descNominal.concat(`The categories are shown with the ${arrayToString(nominalEncodingsINames)} of the ${markText}.`);
             for (const q of nominalEncodingsI) {
                 descList.push({
-                    channel: channelToText.get(q) as string,
-                    desc: `The ${channelToText.get(q)} of the ${markText} show the different categories.`,
+                    channel: callChannelToText(q) as string,
+                    desc: `The ${callChannelToText(q)} of the ${markText} show the different categories.`,
                     channelType: 'nominal'
                 } as AltEncodingDesc);
             }
@@ -491,10 +492,10 @@ function addEncodingDescriptionsAll(markText: string, encodings: AltEncodingSepa
             } as AltEncodingDesc);
         }
         else {
-            descNominal = descNominal.concat(`The ${channelToText.get(nominalEncodingsI[0])} of the ${markText} indicates the different categories.`);
+            descNominal = descNominal.concat(`The ${callChannelToText(nominalEncodingsI[0])} of the ${markText} indicates the different categories.`);
             descList.push({
-                channel: channelToText.get(nominalEncodingsI[0]) as string,
-                desc: `The ${channelToText.get(nominalEncodingsI[0])} of the ${markText} show the different categories.`,
+                channel: callChannelToText(nominalEncodingsI[0]) as string,
+                desc: `The ${callChannelToText(nominalEncodingsI[0])} of the ${markText} show the different categories.`,
                 channelType: 'nominal'
             } as AltEncodingDesc);
         }

--- a/src/alt-gosling-model/util.ts
+++ b/src/alt-gosling-model/util.ts
@@ -71,7 +71,7 @@ export function capDesc(desc: string): string {
 /**
  * Mapping from mark name to a natural language description of said mark
  */
-const markToText = new Map([['point', 'points'], ['line', 'lines'], ['bar', 'bars'], ['rect', 'rectangles'], ['area', 'area displayed'], ['withinLink', 'connections'], ['betweenLink', 'connections'], ['triangleLeft', 'triangles'], ['triangleRight', 'triangles'], ['triangleBottom', 'triangles'], ['text', 'text'], ['rule', 'lines'], ['brush', 'with linked view']]);
+const markToText = new Map([['point', 'points'], ['line', 'lines'], ['bar', 'bars'], ['rect', 'rectangles'], ['area', 'area displayed'], ['withinLink', 'connections'], ['betweenLink', 'connections'], ['triangleLeft', 'left triangles'], ['triangleRight', 'right triangles'], ['triangleBottom', 'triangles'], ['text', 'text'], ['rule', 'lines'], ['brush', 'with linked view']]);
 
 /**
  * Use markToText map. If mark is not in map, return the mark as is.

--- a/src/alt-gosling-model/util.ts
+++ b/src/alt-gosling-model/util.ts
@@ -71,12 +71,26 @@ export function capDesc(desc: string): string {
 /**
  * Mapping from mark name to a natural language description of said mark
  */
-export const markToText = new Map([['point', 'points'], ['line', 'lines'], ['bar', 'bars'], ['rect', 'rectangles'], ['area', 'area displayed'], ['withinLink', 'connections'], ['betweenLink', 'connections'], ['triangleLeft', 'triangles'], ['triangleRight', 'triangles'], ['triangleBottom', 'triangles'], ['text', 'text'], ['rule', 'lines'], ['brush', 'with linked view']]);
+const markToText = new Map([['point', 'points'], ['line', 'lines'], ['bar', 'bars'], ['rect', 'rectangles'], ['area', 'area displayed'], ['withinLink', 'connections'], ['betweenLink', 'connections'], ['triangleLeft', 'triangles'], ['triangleRight', 'triangles'], ['triangleBottom', 'triangles'], ['text', 'text'], ['rule', 'lines'], ['brush', 'with linked view']]);
+
+/**
+ * Use markToText map. If mark is not in map, return the mark as is.
+ */
+export function callMarkToText(mark: string) {
+    return markToText.get(mark) ?? mark;
+}
 
 /**
  * Mapping of channel name to a natural language description of said channel
  */
-export const channelToText = new Map([['y', 'height'], ['color', 'color'], ['strokeWidth', 'stroke width'], ['opacity', 'opacity'], ['text', 'text'], ['size', 'size']]);
+const channelToText = new Map([['y', 'height'], ['color', 'color'], ['strokeWidth', 'stroke width'], ['opacity', 'opacity'], ['text', 'text'], ['size', 'size']]);
+
+/**
+ * Use channelToText map. If channel is not in map, return the channel as is.
+ */
+export function callChannelToText(channel: string) {
+    return channelToText.get(channel) ?? channel;
+}
 
 /**
  * Function to remove the suffix 'chr' from a string if present

--- a/src/alt-gosling-model/util.ts
+++ b/src/alt-gosling-model/util.ts
@@ -38,11 +38,14 @@ export function attributeExistsReturn(object: any, attribute: any) {
 
 /**
  * Function for concatination an array into a natural language sentence
- * @param arr array with elements of string or number
+ * @param arr string or array with elements of string or number
  * @returns string with elements concatenated with commas and 'and'
  * E.g., if arr is ['first', 'second', 'third'], this will return 'first, second and third'
  */
-export function arrayToString(arr: (string | number | undefined)[]): string {
+export function arrayToString(arr: string | (string | number | undefined)[]): string {
+    if (typeof arr === 'string') {
+        return arr;
+    }
     arr = arr.filter(a => a !== undefined);
     if (arr.length === 0) {
         return '';

--- a/src/render/alt-tree-mui.tsx
+++ b/src/render/alt-tree-mui.tsx
@@ -357,7 +357,11 @@ function markNode(t: AltTrack | AltTrackOverlaidByDataInd, uid: string): AltNode
         mark = `The mark used is ${t.appearance.details.mark}.`;
     }
     if (t.alttype === 'ov-mark') {
-        mark = `The marks used are ${arrayToString([t.appearance.details.mark, ...t.appearance.details.markByTrack])}.`;
+        if (t.appearance.details.markByTrack) {
+            mark = `The marks used are ${arrayToString([t.appearance.details.mark, ...t.appearance.details.markByTrack])}.`;
+        } else {         
+            mark = `The mark used is ${t.appearance.details.mark}.`;
+        }
     } else {
         return emptyNode();
     }

--- a/src/render/alt-tree-mui.tsx
+++ b/src/render/alt-tree-mui.tsx
@@ -274,7 +274,7 @@ function trackNodeMulti(t: AltTrack): AltNode {
     let structure;
 
     if (t.alttype === 'single' || t.alttype === 'ov-mark') {
-        structure = new AltNode(`Track ${(t.position.details.trackNumber + 1).toString()} (${t.position.description}) (${t.charttype})`, 'T-'+uid, true, true, 'altnodelist', [
+        structure = new AltNode(`Track ${(t.position.details.trackNumber + 1).toString()} (${t.position.description}) (${arrayToString(t.charttype)})`, 'T-'+uid, true, true, 'altnodelist', [
             new AltNode('Title', 'T-'+uid+'-det-title', false, true, 'value', t.title),
             new AltNode('Position', 'T-'+uid+'-det-pos', true, true, 'altnodelist', [
                 new AltNode('Description', 'T-'+uid+'-det-pos-desc', true, false, 'value', t.position.description),

--- a/src/render/util.ts
+++ b/src/render/util.ts
@@ -1,10 +1,13 @@
 /**
  * Function for concatination an array into a natural language sentence
- * @param arr array with elements of string or number
+ * @param arr string or array with elements of string or number
  * @returns string with elements concatenated with commas and 'and'
  * E.g., if arr is ['first', 'second', 'third'], this will return 'first, second and third'
  */
-export function arrayToString(arr: (string | number | undefined)[]): string {
+export function arrayToString(arr: string | (string | number | undefined)[]): string {
+    if (typeof arr === 'string') {
+        return arr;
+    }
     arr = arr.filter(a => a !== undefined);
     if (arr.length === 0) {
         return '';


### PR DESCRIPTION
This PR: 
- fixes the enumeration error if there is an overlaidTrack but only 1 mark (and therefore no markByTrack)
- Uses the arrayToString for node titles as well (for a nice sentence enumeration)
- Replaces the channelToText and markToText maps by a function so that if the encoding or mark does not exist in the map, it will just return the name of the encoding or mark rather than unknown
- Specifies triangles to point left or right